### PR TITLE
Update nalgebra to 0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ default = []
 minpack-compat = []
 
 [dependencies]
-nalgebra = { version = "0.25.3", default-features = false }
+nalgebra = { version = "0.27.1", default-features = false }
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 cfg-if = "1.0.0"
 
 [dev-dependencies]
-arrsac = "0.6.1"
-rand = { version = "0.8.3", default-features = false }
-nalgebra = "0.25.3"
+arrsac = { path = "../arrsac" }
+rand = { version = "0.8.4", default-features = false }
+nalgebra = "0.27.1"
 pcg_rand = "0.13.0"
 sample-consensus = "1.0.1"
-approx = "0.4.0"
+approx = "0.5.0"
 
 [build-dependencies]
 rustc_version = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { version = "0.2.14", default-features = false, features = ["libm"]
 cfg-if = "1.0.0"
 
 [dev-dependencies]
-arrsac = { path = "../arrsac" }
+arrsac = "0.7.0"
 rand = { version = "0.8.4", default-features = false }
 nalgebra = "0.27.1"
 pcg_rand = "0.13.0"

--- a/src/lm.rs
+++ b/src/lm.rs
@@ -6,7 +6,7 @@ use nalgebra::{
     allocator::{Allocator, Reallocator},
     convert,
     storage::Storage,
-    DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, Matrix, RealField, Vector, VectorN, U1,
+    DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, Matrix, OVector, RealField, Vector,
 };
 use num_traits::Float;
 
@@ -322,7 +322,7 @@ where
     gnorm: F,
     residuals_norm: F,
     /// The diagonal of `$\mathbf{D}$`
-    diag: VectorN<F, N>,
+    diag: OVector<F, N>,
     /// Flag to check if it is the first trust region iteration
     first_trust_region_iteration: bool,
     /// Flag to check if it is the first diagonal update
@@ -368,7 +368,7 @@ where
 
         // Initialize diagonal
         let n = x.data.shape().0;
-        let diag = VectorN::<F, N>::from_element_generic(n, U1, F::one());
+        let diag = OVector::<F, N>::from_element_generic(n, Dim::from_usize(1), F::one());
         // Check n > 0
         if diag.nrows() == 0 {
             return Err((

--- a/src/lm/test_examples.rs
+++ b/src/lm/test_examples.rs
@@ -31,12 +31,12 @@ const TOL: f64 = 1.49012e-08;
 
 #[derive(Clone)]
 pub struct LinearFullRank {
-    pub params: VectorN<f64, U5>,
+    pub params: OVector<f64, U5>,
     pub m: usize,
 }
 
 impl LinearFullRank {
-    fn new(params: VectorN<f64, U5>, m: usize) -> Self {
+    fn new(params: OVector<f64, U5>, m: usize) -> Self {
         Self { params, m }
     }
 }
@@ -46,19 +46,20 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearFullRank {
     type ResidualStorage = Owned<f64, Dynamic>;
     type JacobianStorage = Owned<f64, Dynamic, U5>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U5>) {
+    fn set_params(&mut self, params: &OVector<f64, U5>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U5> {
+    fn params(&self) -> OVector<f64, U5> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, Dynamic>> {
+    fn residuals(&self) -> Option<OVector<f64, Dynamic>> {
         let m = Dynamic::from_usize(self.m);
-        let mut residuals = VectorN::<f64, Dynamic>::from_element_generic(
+        let u1 = Dim::from_usize(1);
+        let mut residuals = OVector::<f64, Dynamic>::from_element_generic(
             m,
-            U1,
+            u1,
             -2. * self.params.sum() / self.m as f64 - 1.,
         );
         for (el, p) in residuals
@@ -71,9 +72,10 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearFullRank {
         Some(residuals)
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<f64, Dynamic, U5>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, Dynamic, U5>> {
         let m = Dynamic::from_usize(self.m);
-        let mut jacobian = MatrixMN::from_element_generic(m, U5, -2. / self.m as f64);
+        let u5 = Dim::from_usize(5);
+        let mut jacobian = OMatrix::from_element_generic(m, u5, -2. / self.m as f64);
         for i in 0..5 {
             jacobian[(i, i)] += 1.;
         }
@@ -83,12 +85,12 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearFullRank {
 
 #[derive(Clone)]
 struct LinearRank1 {
-    params: VectorN<f64, U5>,
+    params: OVector<f64, U5>,
     m: usize,
 }
 
 impl LinearRank1 {
-    fn new(params: VectorN<f64, U5>, m: usize) -> Self {
+    fn new(params: OVector<f64, U5>, m: usize) -> Self {
         Self { params, m }
     }
 }
@@ -98,15 +100,15 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1 {
     type ResidualStorage = Owned<f64, Dynamic>;
     type JacobianStorage = Owned<f64, Dynamic, U5>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U5>) {
+    fn set_params(&mut self, params: &OVector<f64, U5>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U5> {
+    fn params(&self) -> OVector<f64, U5> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, Dynamic>> {
+    fn residuals(&self) -> Option<OVector<f64, Dynamic>> {
         let m = Dynamic::from_usize(self.m);
         let weighted_sum: f64 = self
             .params
@@ -114,16 +116,18 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1 {
             .enumerate()
             .map(|(j, p)| (j + 1) as f64 * p)
             .sum();
-        Some(VectorN::<f64, Dynamic>::from_iterator_generic(
+        let u1 = Dim::from_usize(1);
+        Some(OVector::<f64, Dynamic>::from_iterator_generic(
             m,
-            U1,
+            u1,
             (0..self.m).map(|i| (i + 1) as f64 * weighted_sum - 1.),
         ))
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<f64, Dynamic, U5>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, Dynamic, U5>> {
         let m = Dynamic::from_usize(self.m);
-        Some(MatrixMN::from_fn_generic(m, U5, |i, j| {
+        let u5 = Dim::from_usize(5);
+        Some(OMatrix::from_fn_generic(m, u5, |i, j| {
             ((i + 1) * (j + 1)) as f64
         }))
     }
@@ -131,12 +135,12 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1 {
 
 #[derive(Clone)]
 struct LinearRank1ZeroColumns {
-    params: VectorN<f64, U5>,
+    params: OVector<f64, U5>,
     m: usize,
 }
 
 impl LinearRank1ZeroColumns {
-    fn new(params: VectorN<f64, U5>, m: usize) -> Self {
+    fn new(params: OVector<f64, U5>, m: usize) -> Self {
         Self { params, m }
     }
 }
@@ -146,15 +150,15 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1ZeroColumns {
     type ResidualStorage = Owned<f64, Dynamic>;
     type JacobianStorage = Owned<f64, Dynamic, U5>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U5>) {
+    fn set_params(&mut self, params: &OVector<f64, U5>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U5> {
+    fn params(&self) -> OVector<f64, U5> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, Dynamic>> {
+    fn residuals(&self) -> Option<OVector<f64, Dynamic>> {
         let m = Dynamic::from_usize(self.m);
         let weighted_sum: f64 = self
             .params
@@ -168,9 +172,10 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1ZeroColumns {
                 }
             })
             .sum();
-        Some(VectorN::<f64, Dynamic>::from_iterator_generic(
+        let u1 = Dim::from_usize(1);
+        Some(OVector::<f64, Dynamic>::from_iterator_generic(
             m,
-            U1,
+            u1,
             (0..self.m).map(|i| {
                 if i == self.m - 1 {
                     -1.
@@ -181,9 +186,10 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1ZeroColumns {
         ))
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<f64, Dynamic, U5>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, Dynamic, U5>> {
         let m = Dynamic::from_usize(self.m);
-        Some(MatrixMN::from_fn_generic(m, U5, |i, j| {
+        let u5 = Dim::from_usize(5);
+        Some(OMatrix::from_fn_generic(m, u5, |i, j| {
             if i >= 1 && j >= 1 && j < 5 - 1 && i < self.m - 1 {
                 ((j + 1) * i) as f64
             } else {
@@ -195,29 +201,29 @@ impl LeastSquaresProblem<f64, Dynamic, U5> for LinearRank1ZeroColumns {
 
 #[derive(Clone)]
 struct Rosenbruck {
-    params: VectorN<f64, U2>,
+    params: OVector<f64, U2>,
 }
 impl LeastSquaresProblem<f64, U2, U2> for Rosenbruck {
     type ParameterStorage = Owned<f64, U2>;
     type ResidualStorage = Owned<f64, U2>;
     type JacobianStorage = Owned<f64, U2, U2>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U2>) {
+    fn set_params(&mut self, params: &OVector<f64, U2>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U2> {
+    fn params(&self) -> OVector<f64, U2> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, U2>> {
+    fn residuals(&self) -> Option<OVector<f64, U2>> {
         Some(Vector2::new(
             10. * (self.params[1] - self.params[0] * self.params[0]),
             1. - self.params[0],
         ))
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<f64, U2, U2>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U2, U2>> {
         Some(Matrix2::new(-20. * self.params[0], 10., -1., 0.))
     }
 }
@@ -226,22 +232,22 @@ const TPI: f64 = ::core::f64::consts::PI * 2.;
 
 #[derive(Clone)]
 struct HelicalValley {
-    params: VectorN<f64, U3>,
+    params: OVector<f64, U3>,
 }
 impl LeastSquaresProblem<f64, U3, U3> for HelicalValley {
     type ParameterStorage = Owned<f64, U3>;
     type ResidualStorage = Owned<f64, U3>;
     type JacobianStorage = Owned<f64, U3, U3>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U3>) {
+    fn set_params(&mut self, params: &OVector<f64, U3>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U3> {
+    fn params(&self) -> OVector<f64, U3> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, U3>> {
+    fn residuals(&self) -> Option<OVector<f64, U3>> {
         let p = self.params;
         let tmp1 = if p[0] == 0. {
             (0.25f64).copysign(p[1])
@@ -259,7 +265,7 @@ impl LeastSquaresProblem<f64, U3, U3> for HelicalValley {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U3, U3>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U3, U3>> {
         let p = self.params;
         let temp = p[0] * p[0] + p[1] * p[1];
         let tmp1 = TPI * temp;
@@ -274,22 +280,22 @@ impl LeastSquaresProblem<f64, U3, U3> for HelicalValley {
 
 #[derive(Clone)]
 struct PowellSingular {
-    params: VectorN<f64, U4>,
+    params: OVector<f64, U4>,
 }
 impl LeastSquaresProblem<f64, U4, U4> for PowellSingular {
     type ParameterStorage = Owned<f64, U4>;
     type ResidualStorage = Owned<f64, U4>;
     type JacobianStorage = Owned<f64, U4, U4>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U4>) {
+    fn set_params(&mut self, params: &OVector<f64, U4>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U4> {
+    fn params(&self) -> OVector<f64, U4> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, U4>> {
+    fn residuals(&self) -> Option<OVector<f64, U4>> {
         let p = self.params;
         Some(Vector4::new(
             p[0] + 10. * p[1],
@@ -300,7 +306,7 @@ impl LeastSquaresProblem<f64, U4, U4> for PowellSingular {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U4, U4>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U4, U4>> {
         let p = self.params;
         let f = (5.).sqrt();
         let t = (10.).sqrt();
@@ -317,23 +323,23 @@ impl LeastSquaresProblem<f64, U4, U4> for PowellSingular {
 
 #[derive(Clone)]
 struct FreudensteinRoth {
-    params: VectorN<f64, U2>,
+    params: OVector<f64, U2>,
 }
 impl LeastSquaresProblem<f64, U2, U2> for FreudensteinRoth {
     type ParameterStorage = Owned<f64, U2>;
     type ResidualStorage = Owned<f64, U2>;
     type JacobianStorage = Owned<f64, U2, U2>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U2>) {
+    fn set_params(&mut self, params: &OVector<f64, U2>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U2> {
+    fn params(&self) -> OVector<f64, U2> {
         self.params
     }
 
     #[rustfmt::skip]
-    fn residuals(&self) -> Option<VectorN<f64, U2>> {
+    fn residuals(&self) -> Option<OVector<f64, U2>> {
         let p = &self.params;
         Some(Vector2::new(
             -13. + p[0] + ((5. - p[1]) * p[1] - 2.) * p[1],
@@ -342,7 +348,7 @@ impl LeastSquaresProblem<f64, U2, U2> for FreudensteinRoth {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U2, U2>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U2, U2>> {
         let p = &self.params;
         Some(Matrix2::new(
             1. , p[1] * (10. - 3. * p[1]) - 2.,
@@ -353,30 +359,30 @@ impl LeastSquaresProblem<f64, U2, U2> for FreudensteinRoth {
 
 #[derive(Clone)]
 struct Bard {
-    params: VectorN<f64, U3>,
+    params: OVector<f64, U3>,
 }
 impl LeastSquaresProblem<f64, U15, U3> for Bard {
     type ParameterStorage = Owned<f64, U3>;
     type ResidualStorage = Owned<f64, U15>;
     type JacobianStorage = Owned<f64, U15, U3>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U3>) {
+    fn set_params(&mut self, params: &OVector<f64, U3>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U3> {
+    fn params(&self) -> OVector<f64, U3> {
         self.params
     }
 
     #[rustfmt::skip]
-    fn residuals(&self) -> Option<VectorN<f64, U15>> {
+    fn residuals(&self) -> Option<OVector<f64, U15>> {
         const Y1: [f64; 15] = [
             0.14, 0.18, 0.22, 0.25, 0.29,
             0.32, 0.35, 0.39, 0.37, 0.58,
             0.73, 0.96, 1.34, 2.10, 4.39,
         ];
         let p = &self.params;
-        Some(VectorN::<f64, U15>::from_fn(|i, _j| {
+        Some(OVector::<f64, U15>::from_fn(|i, _j| {
             let tmp2 = (15 - i) as f64;
             let tmp3 = if i > 7 { tmp2 } else { (i + 1) as f64 };
             Y1[i] - (p[0] + (i + 1) as f64 / (p[1] * tmp2 + p[2] * tmp3))
@@ -384,9 +390,9 @@ impl LeastSquaresProblem<f64, U15, U3> for Bard {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U15, U3>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U15, U3>> {
         let p = &self.params;
-        Some(MatrixMN::<f64, U15, U3>::from_fn(|i, j| {
+        Some(OMatrix::<f64, U15, U3>::from_fn(|i, j| {
             let tmp2 = (15 - i) as f64;
             let tmp3 = if i > 7 { tmp2 } else { (i + 1) as f64 };
             let tmp4 = (p[1] * tmp2 + p[2] * tmp3).powi(2);
@@ -402,7 +408,7 @@ impl LeastSquaresProblem<f64, U15, U3> for Bard {
 
 #[derive(Clone)]
 struct KowalikOsborne {
-    params: VectorN<f64, U4>,
+    params: OVector<f64, U4>,
 }
 const V: [f64; 11] = [
     4., 2., 1., 0.5, 0.25, 0.167, 0.125, 0.1, 0.0833, 0.0714, 0.0625,
@@ -415,18 +421,18 @@ impl LeastSquaresProblem<f64, U11, U4> for KowalikOsborne {
     type ResidualStorage = Owned<f64, U11>;
     type JacobianStorage = Owned<f64, U11, U4>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U4>) {
+    fn set_params(&mut self, params: &OVector<f64, U4>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U4> {
+    fn params(&self) -> OVector<f64, U4> {
         self.params
     }
 
     #[rustfmt::skip]
-    fn residuals(&self) -> Option<VectorN<f64, U11>> {
+    fn residuals(&self) -> Option<OVector<f64, U11>> {
         let p = &self.params;
-        Some(VectorN::<f64, U11>::from_fn(|i, _j| {
+        Some(OVector::<f64, U11>::from_fn(|i, _j| {
             let tmp1 = V[i] * (V[i] + p[1]);
             let tmp2 = V[i] * (V[i] + p[2]) + p[3];
             Y2[i] - p[0] * tmp1 / tmp2
@@ -434,9 +440,9 @@ impl LeastSquaresProblem<f64, U11, U4> for KowalikOsborne {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U11, U4>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U11, U4>> {
         let p = &self.params;
-        Some(MatrixMN::<f64, U11, U4>::from_fn(|i, j| {
+        Some(OMatrix::<f64, U11, U4>::from_fn(|i, j| {
             let tmp1 = V[i] * (V[i] + p[1]);
             let tmp2 = V[i] * (V[i] + p[2]) + p[3];
             match j {
@@ -459,34 +465,34 @@ const Y3: [f64; 16] = [
 ];
 #[derive(Clone)]
 struct Meyer {
-    params: VectorN<f64, U3>,
+    params: OVector<f64, U3>,
 }
 impl LeastSquaresProblem<f64, U16, U3> for Meyer {
     type ParameterStorage = Owned<f64, U3>;
     type ResidualStorage = Owned<f64, U16>;
     type JacobianStorage = Owned<f64, U16, U3>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U3>) {
+    fn set_params(&mut self, params: &OVector<f64, U3>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U3> {
+    fn params(&self) -> OVector<f64, U3> {
         self.params
     }
 
     #[rustfmt::skip]
-    fn residuals(&self) -> Option<VectorN<f64, U16>> {
+    fn residuals(&self) -> Option<OVector<f64, U16>> {
         let p = &self.params;
-        Some(VectorN::<f64, U16>::from_fn(|i, _j| {
+        Some(OVector::<f64, U16>::from_fn(|i, _j| {
             let temp = 5. * (i + 1) as f64 + 45. + p[2];
             p[0] * (p[1] / temp).exp() - Y3[i]
         }))
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U16, U3>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U16, U3>> {
         let p = &self.params;
-        Some(MatrixMN::<f64, U16, U3>::from_fn(|i, j| {
+        Some(OMatrix::<f64, U16, U3>::from_fn(|i, j| {
             let temp = 5. * (i + 1) as f64 + 45. + p[2];
             let tmp1 = p[1] / temp;
             let tmp2 = tmp1.exp();
@@ -505,14 +511,14 @@ struct Watson<P: DimName>
 where
     DefaultAllocator: Allocator<f64, P>,
 {
-    params: VectorN<f64, P>,
+    params: OVector<f64, P>,
 }
 
 impl<P: DimName> Watson<P>
 where
     DefaultAllocator: Allocator<f64, P>,
 {
-    fn new(params: VectorN<f64, P>, _n: usize) -> Self {
+    fn new(params: OVector<f64, P>, _n: usize) -> Self {
         Self { params }
     }
 }
@@ -525,31 +531,31 @@ where
     type ResidualStorage = Owned<f64, U31>;
     type JacobianStorage = Owned<f64, U31, P>;
 
-    fn set_params(&mut self, params: &VectorN<f64, P>) {
+    fn set_params(&mut self, params: &OVector<f64, P>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, P> {
+    fn params(&self) -> OVector<f64, P> {
         self.params.clone()
     }
 
     #[rustfmt::skip]
-    fn residuals(&self) -> Option<VectorN<f64, U31>> {
+    fn residuals(&self) -> Option<OVector<f64, U31>> {
         let params = &self.params;
-        let div = VectorN::<f64, U29>::from_fn(|i,_| (i + 1) as f64 / 29.);
-        let mut s1 = VectorN::<f64, U29>::zeros();
-        let mut dx = VectorN::<f64, U29>::from_element(1.);
+        let div = OVector::<f64, U29>::from_fn(|i,_| (i + 1) as f64 / 29.);
+        let mut s1 = OVector::<f64, U29>::zeros();
+        let mut dx = OVector::<f64, U29>::from_element(1.);
         for (j, p) in params.iter().enumerate().skip(1) {
             s1 += (j as f64 * *p) * dx;
             dx.component_mul_assign(&div);
         }
-        let mut s2 = VectorN::<f64, U29>::zeros();
-        let mut dx = VectorN::<f64, U29>::from_element(1.);
+        let mut s2 = OVector::<f64, U29>::zeros();
+        let mut dx = OVector::<f64, U29>::from_element(1.);
         for p in params.iter() {
             s2 += dx * *p;
             dx.component_mul_assign(&div);
         }
-        let mut residuals = VectorN::<f64, U31>::zeros();
+        let mut residuals = OVector::<f64, U31>::zeros();
         s1.cmpy(-1., &s2, &s2, 1.);
         s1.apply(|x| x - 1.);
         residuals.rows_range_mut(..29).copy_from(&s1);
@@ -559,21 +565,21 @@ where
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U31, P>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U31, P>> {
         let params = &self.params;
-        let div = VectorN::<f64, U29>::from_fn(|i,_| (i + 1) as f64 / 29.);
-        let mut s2 = VectorN::<f64, U29>::zeros();
-        let mut dx = VectorN::<f64, U29>::from_element(1.);
+        let div = OVector::<f64, U29>::from_fn(|i,_| (i + 1) as f64 / 29.);
+        let mut s2 = OVector::<f64, U29>::zeros();
+        let mut dx = OVector::<f64, U29>::from_element(1.);
         for p in params.iter() {
             s2 += dx * *p;
             dx.component_mul_assign(&div);
         }
-        let mut temp = VectorN::<f64, U29>::zeros();
+        let mut temp = OVector::<f64, U29>::zeros();
         temp.cmpy(2., &div, &s2, 0.);
         dx.copy_from(&div);
         dx.apply(|x| x.recip());
 
-        let mut jac = MatrixMN::<f64, U31, P>::zeros();
+        let mut jac = OMatrix::<f64, U31, P>::zeros();
         for j in 0..params.len() {
             let mut col = jac.column_mut(j);
             let mut col_slice = col.rows_range_mut(..29);
@@ -590,7 +596,7 @@ where
 
 #[derive(Clone)]
 struct Beale {
-    params: VectorN<f64, U2>,
+    params: OVector<f64, U2>,
 }
 
 impl LeastSquaresProblem<f64, U1, U2> for Beale {
@@ -598,15 +604,15 @@ impl LeastSquaresProblem<f64, U1, U2> for Beale {
     type ResidualStorage = Owned<f64, U1>;
     type JacobianStorage = Owned<f64, U1, U2>;
 
-    fn set_params(&mut self, params: &VectorN<f64, U2>) {
+    fn set_params(&mut self, params: &OVector<f64, U2>) {
         self.params.copy_from(params);
     }
 
-    fn params(&self) -> VectorN<f64, U2> {
+    fn params(&self) -> OVector<f64, U2> {
         self.params
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, U1>> {
+    fn residuals(&self) -> Option<OVector<f64, U1>> {
         let p = self.params;
         Some(Vector1::new(
             (1.5 - p[0] + p[0] * p[1]).powi(2) + (2.25 - p[0] + p[0] * (p[1] * p[1])).powi(2),
@@ -614,7 +620,7 @@ impl LeastSquaresProblem<f64, U1, U2> for Beale {
     }
 
     #[rustfmt::skip]
-    fn jacobian(&self) -> Option<MatrixMN<f64, U1, U2>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, U1, U2>> {
         let x = self.params[0];
         let y = self.params[1];
         let y3 = y * y * y;

--- a/src/lm/test_examples_gen.rs
+++ b/src/lm/test_examples_gen.rs
@@ -2,11 +2,11 @@
 
 #[test]
 fn test_linear_full_rank() {
-    let mut problem = LinearFullRank::new(VectorN::<f64, U5>::zeros(), 10);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearFullRank::new(OVector::<f64, U5>::zeros(), 10);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U5>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U5>::from_column_slice(&[
         0.5488135039273248,
         0.7151893663724195,
         0.6027633760716439,
@@ -32,7 +32,7 @@ fn test_linear_full_rank() {
     assert_fp_eq!(report.objective_function, 2.5000000000000004);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             -1.,
             -1.0000000000000004,
             -1.,
@@ -41,8 +41,8 @@ fn test_linear_full_rank() {
         ])
     );
 
-    let mut problem = LinearFullRank::new(VectorN::<f64, U5>::zeros(), 50);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearFullRank::new(OVector::<f64, U5>::zeros(), 50);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     problem.set_params(&initial.clone());
     let (problem, report) = LevenbergMarquardt::new()
@@ -59,7 +59,7 @@ fn test_linear_full_rank() {
     assert_fp_eq!(report.objective_function, 22.500000000000004);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             -0.9999999999999953,
             -1.0000000000000049,
             -0.9999999999999976,
@@ -71,11 +71,11 @@ fn test_linear_full_rank() {
 
 #[test]
 fn test_linear_rank1() {
-    let mut problem = LinearRank1::new(VectorN::<f64, U5>::zeros(), 10);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearRank1::new(OVector::<f64, U5>::zeros(), 10);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U5>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U5>::from_column_slice(&[
         0.6458941130666561,
         0.4375872112626925,
         0.8917730007820798,
@@ -101,7 +101,7 @@ fn test_linear_rank1() {
     assert_fp_eq!(report.objective_function, 1.0714285714285714);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             -167.79681802396928,
             -83.39840901198468,
             221.11004307957813,
@@ -110,8 +110,8 @@ fn test_linear_rank1() {
         ])
     );
 
-    let mut problem = LinearRank1::new(VectorN::<f64, U5>::zeros(), 50);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearRank1::new(OVector::<f64, U5>::zeros(), 50);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     problem.set_params(&initial.clone());
     let (problem, report) = LevenbergMarquardt::new()
@@ -128,7 +128,7 @@ fn test_linear_rank1() {
     assert_fp_eq!(report.objective_function, 6.064356435643563);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             -20.29999900022674,
             -9.64999950011337,
             -165.2451975264496,
@@ -140,11 +140,11 @@ fn test_linear_rank1() {
 
 #[test]
 fn test_linear_rank1_zero_columns() {
-    let mut problem = LinearRank1ZeroColumns::new(VectorN::<f64, U5>::zeros(), 10);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearRank1ZeroColumns::new(OVector::<f64, U5>::zeros(), 10);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U5>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U5>::from_column_slice(&[
         0.7917250380826646,
         0.5288949197529045,
         0.5680445610939323,
@@ -170,7 +170,7 @@ fn test_linear_rank1_zero_columns() {
     assert_fp_eq!(report.objective_function, 1.8235294117647063);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             1.,
             -210.3615324224772,
             32.120420811321296,
@@ -179,8 +179,8 @@ fn test_linear_rank1_zero_columns() {
         ])
     );
 
-    let mut problem = LinearRank1ZeroColumns::new(VectorN::<f64, U5>::zeros(), 50);
-    let initial = VectorN::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
+    let mut problem = LinearRank1ZeroColumns::new(OVector::<f64, U5>::zeros(), 50);
+    let initial = OVector::<f64, U5>::from_column_slice(&[1., 1., 1., 1., 1.]);
 
     problem.set_params(&initial.clone());
     let (problem, report) = LevenbergMarquardt::new()
@@ -197,7 +197,7 @@ fn test_linear_rank1_zero_columns() {
     assert_fp_eq!(report.objective_function, 6.814432989690721);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U5>::from_column_slice(&[
+        OVector::<f64, U5>::from_column_slice(&[
             1.,
             332.1494858957815,
             -439.6851914289522,
@@ -210,12 +210,12 @@ fn test_linear_rank1_zero_columns() {
 #[test]
 fn test_rosenbruck() {
     let mut problem = Rosenbruck {
-        params: VectorN::<f64, U2>::zeros(),
+        params: OVector::<f64, U2>::zeros(),
     };
-    let initial = VectorN::<f64, U2>::from_column_slice(&[-1.2, 1.]);
+    let initial = OVector::<f64, U2>::from_column_slice(&[-1.2, 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U2>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U2>::from_column_slice(&[
         0.08712929970154071,
         0.02021839744032572,
     ]));
@@ -236,7 +236,7 @@ fn test_rosenbruck() {
     assert_fp_eq!(report.objective_function, 0.0);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[1., 1.])
+        OVector::<f64, U2>::from_column_slice(&[1., 1.])
     );
     problem.set_params(&initial.map(|x| x * 10.));
     let (mut problem, report) = LevenbergMarquardt::new()
@@ -257,7 +257,7 @@ fn test_rosenbruck() {
     assert_fp_eq!(report.objective_function, 0.0);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[1., 1.])
+        OVector::<f64, U2>::from_column_slice(&[1., 1.])
     );
     problem.set_params(&initial.map(|x| x * 100.));
     let (problem, report) = LevenbergMarquardt::new()
@@ -278,19 +278,19 @@ fn test_rosenbruck() {
     assert_fp_eq!(report.objective_function, 0.0);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[1., 1.])
+        OVector::<f64, U2>::from_column_slice(&[1., 1.])
     );
 }
 
 #[test]
 fn test_helical_valley() {
     let mut problem = HelicalValley {
-        params: VectorN::<f64, U3>::zeros(),
+        params: OVector::<f64, U3>::zeros(),
     };
-    let initial = VectorN::<f64, U3>::from_column_slice(&[-1., 0., 0.]);
+    let initial = OVector::<f64, U3>::from_column_slice(&[-1., 0., 0.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U3>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U3>::from_column_slice(&[
         0.832619845547938,
         0.7781567509498505,
         0.8700121482468192,
@@ -314,7 +314,7 @@ fn test_helical_valley() {
     assert_fp_eq!(report.objective_function, 4.936724569245567e-33);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[1., -6.243301596789443e-18, 0.])
+        OVector::<f64, U3>::from_column_slice(&[1., -6.243301596789443e-18, 0.])
     );
     problem.set_params(&initial.map(|x| x * 10.));
     let (mut problem, report) = LevenbergMarquardt::new()
@@ -331,7 +331,7 @@ fn test_helical_valley() {
     assert_fp_eq!(report.objective_function, 5.456769505027268e-39);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[1., 6.563910805155555e-21, 0.])
+        OVector::<f64, U3>::from_column_slice(&[1., 6.563910805155555e-21, 0.])
     );
     problem.set_params(&initial.map(|x| x * 100.));
     let (problem, report) = LevenbergMarquardt::new()
@@ -348,19 +348,19 @@ fn test_helical_valley() {
     assert_fp_eq!(report.objective_function, 4.9259630763847064e-58);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[1., -1.9721522630525295e-30, 0.])
+        OVector::<f64, U3>::from_column_slice(&[1., -1.9721522630525295e-30, 0.])
     );
 }
 
 #[test]
 fn test_powell_singular() {
     let mut problem = PowellSingular {
-        params: VectorN::<f64, U4>::zeros(),
+        params: OVector::<f64, U4>::zeros(),
     };
-    let initial = VectorN::<f64, U4>::from_column_slice(&[3., -1., 0., 1.]);
+    let initial = OVector::<f64, U4>::from_column_slice(&[3., -1., 0., 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U4>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U4>::from_column_slice(&[
         0.978618342232764,
         0.7991585642167236,
         0.46147936225293185,
@@ -382,7 +382,7 @@ fn test_powell_singular() {
     assert_fp_eq!(report.objective_function, 1.866194344564614e-67);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             1.6521175961683935e-17,
             -1.6521175961683934e-18,
             2.6433881538694683e-18,
@@ -401,7 +401,7 @@ fn test_powell_singular() {
     assert_fp_eq!(report.objective_function, 4.14378385952174e-79);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             2.0167451125102287e-20,
             -2.0167451125102287e-21,
             3.2267921800163004e-21,
@@ -420,7 +420,7 @@ fn test_powell_singular() {
     assert_fp_eq!(report.objective_function, 2.715670190176167e-70);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             3.2267921800163781e-18,
             -3.2267921800163780e-19,
             5.1628674880262125e-19,
@@ -432,12 +432,12 @@ fn test_powell_singular() {
 #[test]
 fn test_freudenstein_roth() {
     let mut problem = FreudensteinRoth {
-        params: VectorN::<f64, U2>::zeros(),
+        params: OVector::<f64, U2>::zeros(),
     };
-    let initial = VectorN::<f64, U2>::from_column_slice(&[0.5, -2.]);
+    let initial = OVector::<f64, U2>::from_column_slice(&[0.5, -2.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U2>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U2>::from_column_slice(&[
         0.11827442586893322,
         0.6399210213275238,
     ]));
@@ -460,7 +460,7 @@ fn test_freudenstein_roth() {
     assert_fp_eq!(report.objective_function, 24.492126863534953);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[11.412484465499368, -0.8968279137315035])
+        OVector::<f64, U2>::from_column_slice(&[11.412484465499368, -0.8968279137315035])
     );
     problem.set_params(&initial.map(|x| x * 10.));
     let (mut problem, report) = LevenbergMarquardt::new()
@@ -477,7 +477,7 @@ fn test_freudenstein_roth() {
     assert_fp_eq!(report.objective_function, 24.492126854042752);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[11.413004661474561, -0.8967960386859591])
+        OVector::<f64, U2>::from_column_slice(&[11.413004661474561, -0.8967960386859591])
     );
     problem.set_params(&initial.map(|x| x * 100.));
     let (problem, report) = LevenbergMarquardt::new()
@@ -494,19 +494,19 @@ fn test_freudenstein_roth() {
     assert_fp_eq!(report.objective_function, 24.49212683962172);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[11.412781785788198, -0.8968051074920677])
+        OVector::<f64, U2>::from_column_slice(&[11.412781785788198, -0.8968051074920677])
     );
 }
 
 #[test]
 fn test_bard() {
     let mut problem = Bard {
-        params: VectorN::<f64, U3>::zeros(),
+        params: OVector::<f64, U3>::zeros(),
     };
-    let initial = VectorN::<f64, U3>::from_column_slice(&[1., 1., 1.]);
+    let initial = OVector::<f64, U3>::from_column_slice(&[1., 1., 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U3>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U3>::from_column_slice(&[
         0.1433532874090464,
         0.9446689170495839,
         0.5218483217500717,
@@ -530,7 +530,7 @@ fn test_bard() {
     assert_fp_eq!(report.objective_function, 0.00410743865329062);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[
+        OVector::<f64, U3>::from_column_slice(&[
             0.0824105765758334,
             1.1330366534715044,
             2.343694638941154
@@ -551,7 +551,7 @@ fn test_bard() {
     assert_fp_eq!(report.objective_function, 8.71434685503351);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[
+        OVector::<f64, U3>::from_column_slice(&[
             8.4066667381832927e-01,
             -1.5884803325956547e+08,
             -1.6437867165353525e+08
@@ -572,7 +572,7 @@ fn test_bard() {
     assert_fp_eq!(report.objective_function, 8.714346854926243);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U3>::from_column_slice(&[
+        OVector::<f64, U3>::from_column_slice(&[
             8.4066667386764549e-01,
             -1.5894616720551842e+08,
             -1.6446490685777116e+08
@@ -583,12 +583,12 @@ fn test_bard() {
 #[test]
 fn test_kowalik_osborne() {
     let mut problem = KowalikOsborne {
-        params: VectorN::<f64, U4>::zeros(),
+        params: OVector::<f64, U4>::zeros(),
     };
-    let initial = VectorN::<f64, U4>::from_column_slice(&[0.25, 0.39, 0.415, 0.39]);
+    let initial = OVector::<f64, U4>::from_column_slice(&[0.25, 0.39, 0.415, 0.39]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U4>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U4>::from_column_slice(&[
         0.4146619399905236,
         0.26455561210462697,
         0.7742336894342167,
@@ -613,7 +613,7 @@ fn test_kowalik_osborne() {
     assert_fp_eq!(report.objective_function, 0.00015375280229088455);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             0.19280781047624931,
             0.1912626533540709,
             0.12305280104693087,
@@ -635,7 +635,7 @@ fn test_kowalik_osborne() {
     assert_fp_eq!(report.objective_function, 0.000513671535424324);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             7.2867547376865975e+05,
             -1.4075880312939264e+01,
             -3.2977797784196608e+07,
@@ -651,7 +651,7 @@ fn test_kowalik_osborne() {
     assert_fp_eq!(report.objective_function, 0.00015375283657222266);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U4>::from_column_slice(&[
+        OVector::<f64, U4>::from_column_slice(&[
             0.19279840638465487,
             0.1914736844615448,
             0.1230924753714115,
@@ -663,12 +663,12 @@ fn test_kowalik_osborne() {
 #[test]
 fn test_meyer() {
     let mut problem = Meyer {
-        params: VectorN::<f64, U3>::zeros(),
+        params: OVector::<f64, U3>::zeros(),
     };
-    let initial = VectorN::<f64, U3>::from_column_slice(&[2.0e-02, 4.0e+03, 2.5e+02]);
+    let initial = OVector::<f64, U3>::from_column_slice(&[2.0e-02, 4.0e+03, 2.5e+02]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U3>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U3>::from_column_slice(&[
         0.5684339488686485,
         0.018789800436355142,
         0.6176354970758771,
@@ -694,7 +694,7 @@ fn test_meyer() {
         assert_fp_eq!(report.objective_function, 43.972927585339875);
         assert_fp_eq!(
             problem.params,
-            VectorN::<f64, U3>::from_column_slice(&[
+            OVector::<f64, U3>::from_column_slice(&[
                 5.609636471027749e-03,
                 6.181346346286417e+03,
                 3.452236346241380e+02
@@ -709,7 +709,7 @@ fn test_meyer() {
         assert_fp_eq!(report.objective_function, 324272.8973474361);
         assert_fp_eq!(
             problem.params,
-            VectorN::<f64, U3>::from_column_slice(&[
+            OVector::<f64, U3>::from_column_slice(&[
                 6.825630280624222e-12,
                 3.514598925134810e+04,
                 9.220430560142615e+02
@@ -734,7 +734,7 @@ fn test_meyer() {
         #[cfg(feature = "minpack-compat")]
         assert_fp_eq!(
             problem.params,
-            VectorN::<f64, U3>::from_column_slice(&[
+            OVector::<f64, U3>::from_column_slice(&[
                 5.6096364710271603e-03,
                 6.1813463462865056e+03,
                 3.4522363462414097e+02
@@ -751,7 +751,7 @@ fn test_meyer() {
         #[cfg(feature = "minpack-compat")]
         assert_fp_eq!(
             problem.params,
-            VectorN::<f64, U3>::from_column_slice(&[
+            OVector::<f64, U3>::from_column_slice(&[
                 6.825607045203072e-12,
                 3.514599603833739e+04,
                 9.220431522058431e+02
@@ -762,11 +762,11 @@ fn test_meyer() {
 
 #[test]
 fn test_watson() {
-    let mut problem = Watson::new(VectorN::<f64, U6>::zeros(), 6);
-    let initial = VectorN::<f64, U6>::from_column_slice(&[0., 0., 0., 0., 0., 0.]);
+    let mut problem = Watson::new(OVector::<f64, U6>::zeros(), 6);
+    let initial = OVector::<f64, U6>::from_column_slice(&[0., 0., 0., 0., 0., 0.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U6>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U6>::from_column_slice(&[
         0.6120957227224214,
         0.6169339968747569,
         0.9437480785146242,
@@ -793,7 +793,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 0.001143835026786261);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U6>::from_column_slice(&[
+        OVector::<f64, U6>::from_column_slice(&[
             -0.01572496150837828,
             1.0124348823296545,
             -0.23299172238767143,
@@ -817,7 +817,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 0.0011438350267831846);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U6>::from_column_slice(&[
+        OVector::<f64, U6>::from_column_slice(&[
             -0.015725190138667525,
             1.0124348586010505,
             -0.23299154584382673,
@@ -841,7 +841,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 0.0011438350268716062);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U6>::from_column_slice(&[
+        OVector::<f64, U6>::from_column_slice(&[
             -0.01572470197125869,
             1.0124349092565827,
             -0.2329919227616415,
@@ -851,8 +851,8 @@ fn test_watson() {
         ])
     );
 
-    let mut problem = Watson::new(VectorN::<f64, U9>::zeros(), 9);
-    let initial = VectorN::<f64, U9>::from_column_slice(&[0., 0., 0., 0., 0., 0., 0., 0., 0.]);
+    let mut problem = Watson::new(OVector::<f64, U9>::zeros(), 9);
+    let initial = OVector::<f64, U9>::from_column_slice(&[0., 0., 0., 0., 0., 0., 0., 0., 0.]);
 
     problem.set_params(&initial.clone());
     let (mut problem, report) = LevenbergMarquardt::new()
@@ -869,7 +869,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 6.998800690506343e-07);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U9>::from_column_slice(&[
+        OVector::<f64, U9>::from_column_slice(&[
             -1.5307064416628804e-05,
             9.9978970393459676e-01,
             1.4763963491099890e-02,
@@ -896,7 +896,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 6.998800690471173e-07);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U9>::from_column_slice(&[
+        OVector::<f64, U9>::from_column_slice(&[
             -1.5307036495997912e-05,
             9.9978970393194666e-01,
             1.4763963693703627e-02,
@@ -923,7 +923,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 6.998800690486009e-07);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U9>::from_column_slice(&[
+        OVector::<f64, U9>::from_column_slice(&[
             -1.5306952335212645e-05,
             9.9978970395837152e-01,
             1.4763962518529752e-02,
@@ -936,9 +936,9 @@ fn test_watson() {
         ])
     );
 
-    let mut problem = Watson::new(VectorN::<f64, U12>::zeros(), 12);
+    let mut problem = Watson::new(OVector::<f64, U12>::zeros(), 12);
     let initial =
-        VectorN::<f64, U12>::from_column_slice(&[0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]);
+        OVector::<f64, U12>::from_column_slice(&[0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]);
 
     problem.set_params(&initial.clone());
     let (mut problem, report) = LevenbergMarquardt::new()
@@ -955,7 +955,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 2.3611905506971735e-10);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U12>::from_column_slice(&[
+        OVector::<f64, U12>::from_column_slice(&[
             -6.6380604677589803e-09,
             1.0000016441178612,
             -5.6393221015137217e-04,
@@ -985,7 +985,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 2.361190552167311e-10);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U12>::from_column_slice(&[
+        OVector::<f64, U12>::from_column_slice(&[
             -6.6380604668544608e-09,
             1.0000016441178616,
             -5.6393221029791976e-04,
@@ -1015,7 +1015,7 @@ fn test_watson() {
     assert_fp_eq!(report.objective_function, 2.361190551562772e-10);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U12>::from_column_slice(&[
+        OVector::<f64, U12>::from_column_slice(&[
             -6.6380604636792693e-09,
             1.0000016441178616,
             -5.6393221027197340e-04,
@@ -1035,12 +1035,12 @@ fn test_watson() {
 #[test]
 fn test_beale() {
     let mut problem = Beale {
-        params: VectorN::<f64, U2>::zeros(),
+        params: OVector::<f64, U2>::zeros(),
     };
-    let initial = VectorN::<f64, U2>::from_column_slice(&[2.5, 1.]);
+    let initial = OVector::<f64, U2>::from_column_slice(&[2.5, 1.]);
 
     // check derivative implementation
-    problem.set_params(&VectorN::<f64, U2>::from_column_slice(&[
+    problem.set_params(&OVector::<f64, U2>::from_column_slice(&[
         0.6976311959272649,
         0.06022547162926983,
     ]));
@@ -1057,7 +1057,7 @@ fn test_beale() {
     assert_fp_eq!(report.objective_function, 6.982085570779134e-07);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[2.8252463853580405, 0.4595596246635109])
+        OVector::<f64, U2>::from_column_slice(&[2.8252463853580405, 0.4595596246635109])
     );
     problem.set_params(&initial.map(|x| x - 0.5));
     let (problem, report) = LevenbergMarquardt::new()
@@ -1068,6 +1068,6 @@ fn test_beale() {
     assert_fp_eq!(report.objective_function, 5.355422879172696e-16);
     assert_fp_eq!(
         problem.params,
-        VectorN::<f64, U2>::from_column_slice(&[2.9989956785046323, 0.4997826037201959])
+        OVector::<f64, U2>::from_column_slice(&[2.9989956785046323, 0.4997826037201959])
     );
 }

--- a/src/lm/test_helpers.rs
+++ b/src/lm/test_helpers.rs
@@ -1,7 +1,7 @@
 use alloc::{vec, vec::Vec};
 use core::cell::RefCell;
 
-use nalgebra::{allocator::Allocator, storage::Owned, DefaultAllocator, Dim, MatrixMN, VectorN};
+use nalgebra::{allocator::Allocator, storage::Owned, DefaultAllocator, Dim, OMatrix, OVector};
 
 use crate::LeastSquaresProblem;
 
@@ -18,10 +18,10 @@ where
     DefaultAllocator: Allocator<f64, N> + Allocator<f64, M> + Allocator<f64, M, N>,
 {
     call_history: RefCell<Vec<MockCall>>,
-    params: Vec<VectorN<f64, N>>,
-    residuals: Vec<Option<VectorN<f64, M>>>,
+    params: Vec<OVector<f64, N>>,
+    residuals: Vec<Option<OVector<f64, M>>>,
     residuals_index: RefCell<usize>,
-    pub jacobians: Vec<Option<MatrixMN<f64, M, N>>>,
+    pub jacobians: Vec<Option<OMatrix<f64, M, N>>>,
     jacobians_index: RefCell<usize>,
 }
 
@@ -29,7 +29,7 @@ impl<N: Dim, M: Dim> MockProblem<N, M>
 where
     DefaultAllocator: Allocator<f64, N> + Allocator<f64, M> + Allocator<f64, M, N>,
 {
-    pub fn new(initial: VectorN<f64, N>, residuals: Vec<Option<VectorN<f64, M>>>) -> Self {
+    pub fn new(initial: OVector<f64, N>, residuals: Vec<Option<OVector<f64, M>>>) -> Self {
         Self {
             residuals,
             jacobians: vec![],
@@ -53,16 +53,16 @@ where
     type ParameterStorage = Owned<f64, N>;
     type JacobianStorage = Owned<f64, M, N>;
 
-    fn set_params(&mut self, params: &VectorN<f64, N>) {
+    fn set_params(&mut self, params: &OVector<f64, N>) {
         self.params.push(params.clone());
         self.call_history.borrow_mut().push(MockCall::SetParams);
     }
 
-    fn params(&self) -> VectorN<f64, N> {
+    fn params(&self) -> OVector<f64, N> {
         self.params.last().unwrap().clone()
     }
 
-    fn residuals(&self) -> Option<VectorN<f64, M>> {
+    fn residuals(&self) -> Option<OVector<f64, M>> {
         self.call_history.borrow_mut().push(MockCall::Residuals);
         if *self.residuals_index.borrow() < self.residuals.len() {
             *self.residuals_index.borrow_mut() += 1;
@@ -72,7 +72,7 @@ where
         }
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<f64, M, N>> {
+    fn jacobian(&self) -> Option<OMatrix<f64, M, N>> {
         self.call_history.borrow_mut().push(MockCall::Jacobian);
         if *self.jacobians_index.borrow() < self.jacobians.len() {
             *self.jacobians_index.borrow_mut() += 1;

--- a/src/lm/test_init_step.rs
+++ b/src/lm/test_init_step.rs
@@ -3,7 +3,7 @@ use approx::assert_relative_eq;
 #[cfg(not(feature = "minpack-compat"))]
 use core::f64::{INFINITY, MIN_POSITIVE, NAN};
 
-use nalgebra::{Dim, Dynamic, MatrixMN, Vector2, Vector3, VectorN, U0, U1, U2, U3};
+use nalgebra::{Dim, Dynamic, OMatrix, OVector, Vector2, Vector3, U0, U2, U3};
 
 use super::test_helpers::{MockCall, MockProblem};
 use super::{LevenbergMarquardt, TerminationReason, LM};
@@ -68,7 +68,7 @@ fn already_zero() {
 fn no_params() {
     // no parameters
     let problem = MockProblem::<U0, U3>::new(
-        VectorN::<f64, U0>::zeros(),
+        OVector::<f64, U0>::zeros(),
         vec![Some(Vector3::from_element(1.))],
     );
     let (mut problem, err) = LM::new(&LevenbergMarquardt::new(), problem).err().unwrap();
@@ -82,17 +82,18 @@ fn wrong_dimensions() {
     // first return m=4 residuals, then m=5
     let m1 = Dynamic::from_usize(4);
     let m2 = Dynamic::from_usize(5);
-    let n = U2;
+    let u1 = Dim::from_usize(1);
+    let u2 = Dim::from_usize(2);
     let mut problem = MockProblem::<U2, Dynamic>::new(
-        VectorN::zeros_generic(n, U1),
+        OVector::zeros_generic(u2, u1),
         vec![
-            Some(VectorN::from_element_generic(m1, U1, 223.)),
-            Some(VectorN::from_element_generic(m2, U1, 223.)),
+            Some(OVector::from_element_generic(m1, u1, 223.)),
+            Some(OVector::from_element_generic(m2, u1, 223.)),
         ],
     );
     problem.jacobians = vec![
-        Some(MatrixMN::from_element_generic(m1, n, 100.)),
-        Some(MatrixMN::from_element_generic(m2, n, 100.)),
+        Some(OMatrix::from_element_generic(m1, u2, 100.)),
+        Some(OMatrix::from_element_generic(m2, u2, 100.)),
     ];
     let (_problem, report) = LevenbergMarquardt::new().minimize(problem);
     assert_eq!(
@@ -101,10 +102,10 @@ fn wrong_dimensions() {
     );
 
     let mut problem = MockProblem::<U2, Dynamic>::new(
-        VectorN::zeros_generic(n, U1),
-        vec![Some(VectorN::from_element_generic(m1, U1, 223.))],
+        OVector::zeros_generic(u2, u1),
+        vec![Some(OVector::from_element_generic(m1, u1, 223.))],
     );
-    problem.jacobians = vec![Some(MatrixMN::from_element_generic(m2, n, 100.))];
+    problem.jacobians = vec![Some(OMatrix::from_element_generic(m2, u2, 100.))];
     let (_problem, report) = LevenbergMarquardt::new().minimize(problem);
     assert_eq!(
         report.termination,

--- a/src/trust_region.rs
+++ b/src/trust_region.rs
@@ -68,7 +68,7 @@ where
 
     let is_non_singular = lls.is_non_singular();
     let (mut p, mut l) = lls.solve_with_zero_diagonal();
-    let mut diag_p = p.component_mul(&diag);
+    let mut diag_p = p.component_mul(diag);
     let mut diag_p_norm = enorm(&diag_p);
     let mut fp = diag_p_norm - delta;
     if fp <= delta * convert(P1) {

--- a/src/trust_region.rs
+++ b/src/trust_region.rs
@@ -4,8 +4,8 @@
 use crate::qr::LinearLeastSquaresDiagonalProblem;
 use crate::utils::{dwarf, enorm};
 use nalgebra::{
-    allocator::Allocator, convert, DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, RealField,
-    VectorN,
+    allocator::Allocator, convert, DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, OVector,
+    RealField,
 };
 use num_traits::Float;
 
@@ -13,7 +13,7 @@ pub struct LMParameter<F: RealField, N: Dim>
 where
     DefaultAllocator: Allocator<F, N>,
 {
-    pub step: VectorN<F, N>,
+    pub step: OVector<F, N>,
     pub lambda: F,
     pub dp_norm: F,
 }
@@ -51,7 +51,7 @@ where
 /// information about this algorithm but it misses a few details.
 pub fn determine_lambda_and_parameter_update<F, M, N>(
     lls: &mut LinearLeastSquaresDiagonalProblem<F, M, N>,
-    diag: &VectorN<F, N>,
+    diag: &OVector<F, N>,
     delta: F,
     initial_lambda: F,
 ) -> LMParameter<F, N>

--- a/tests/line_fitting.rs
+++ b/tests/line_fitting.rs
@@ -3,7 +3,7 @@ use levenberg_marquardt::{LeastSquaresProblem, LevenbergMarquardt};
 use nalgebra::{
     dimension::{U1, U2},
     storage::Owned,
-    Dim, Dynamic, Matrix, Matrix2, MatrixMN, VecStorage, Vector2,
+    Dim, Dynamic, Matrix, Matrix2, OMatrix, VecStorage, Vector2,
 };
 use pcg_rand::Pcg64;
 use rand::distributions::Uniform;
@@ -120,8 +120,9 @@ impl<'a> LeastSquaresProblem<F, Dynamic, U2> for LineFittingOptimizationProblem<
         ))
     }
 
-    fn jacobian(&self) -> Option<MatrixMN<F, Dynamic, U2>> {
-        let mut jacobian = MatrixMN::zeros_generic(Dynamic::from_usize(self.points.len() * 2), U2);
+    fn jacobian(&self) -> Option<OMatrix<F, Dynamic, U2>> {
+        let u2 = Dim::from_usize(2);
+        let mut jacobian = OMatrix::zeros_generic(Dynamic::from_usize(self.points.len() * 2), u2);
         for (i, point) in self.points.iter().enumerate() {
             jacobian
                 .slice_range_mut(2 * i..2 * (i + 1), ..)


### PR DESCRIPTION
And transform all that needed to change with the nalgebra update. In particular:
- `MatrixMN` => `OMatrix`
- `VectorN` => `OVector`
- `..._generic_...(U1)` => `let u1 = Dim::from_usize(1); ..._generic_...(u1)`

Currently there is one test that is failing. I think this is a `relative_eq` versus `eq` problem but I'll let you check that.

Also will need to change de dependency `"../arrsac"` to the actual `arrsac` when it's updated so I made this PR a draft one for now.