### PR TITLE
Update nalgebra to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ default = []
 minpack-compat = []
 
 [dependencies]
-nalgebra = { version = "0.28.0", default-features = false }
+nalgebra = { version = "0.29.0", default-features = false }
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 cfg-if = "1.0.0"
 
 [dev-dependencies]
-arrsac = "0.7.0"
+arrsac = "0.9.0"
 rand = { version = "0.8.4", default-features = false }
-nalgebra = "0.28.0"
+nalgebra = "0.29.0"
 pcg_rand = "0.13.0"
-sample-consensus = "1.0.1"
+sample-consensus = "1.0.2"
 approx = "0.5.0"
 
 [build-dependencies]

--- a/src/lm.rs
+++ b/src/lm.rs
@@ -4,9 +4,7 @@ use crate::utils::{enorm, epsmch};
 use crate::LeastSquaresProblem;
 use nalgebra::{
     allocator::{Allocator, Reallocator},
-    convert,
-    storage::Storage,
-    DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, Matrix, OVector, RealField, Vector,
+    convert, DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, Matrix, OVector, RealField, Vector,
 };
 use num_traits::Float;
 
@@ -300,7 +298,7 @@ impl<F: RealField + Float> LevenbergMarquardt<F> {
 /// Struct which holds the state of the LM algorithm and which implements its individual steps.
 struct LM<'a, F, N, M, O>
 where
-    F: RealField,
+    F: RealField + Copy,
     N: Dim,
     M: DimMin<N> + DimMax<N>,
     O: LeastSquaresProblem<F, M, N>,
@@ -333,7 +331,7 @@ where
 
 impl<'a, F, N, M, O> LM<'a, F, N, M, O>
 where
-    F: RealField + Float,
+    F: RealField + Float + Copy,
     N: Dim,
     M: DimMin<N> + DimMax<N>,
     O: LeastSquaresProblem<F, M, N>,
@@ -367,7 +365,7 @@ where
         };
 
         // Initialize diagonal
-        let n = x.data.shape().0;
+        let n = x.shape_generic().0;
         let diag = OVector::<F, N>::from_element_generic(n, Dim::from_usize(1), F::one());
         // Check n > 0
         if diag.nrows() == 0 {

--- a/src/lm/test_examples.rs
+++ b/src/lm/test_examples.rs
@@ -557,7 +557,7 @@ where
         }
         let mut residuals = OVector::<f64, U31>::zeros();
         s1.cmpy(-1., &s2, &s2, 1.);
-        s1.apply(|x| x - 1.);
+        s1.apply(|x| *x -= 1.);
         residuals.rows_range_mut(..29).copy_from(&s1);
         residuals[29] = params[0];
         residuals[30] = params[1] - params[0].powi(2) - 1.;
@@ -577,7 +577,7 @@ where
         let mut temp = OVector::<f64, U29>::zeros();
         temp.cmpy(2., &div, &s2, 0.);
         dx.copy_from(&div);
-        dx.apply(|x| x.recip());
+        dx.apply(|x| *x = x.recip());
 
         let mut jac = OMatrix::<f64, U31, P>::zeros();
         for j in 0..params.len() {

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -1,4 +1,7 @@
-use nalgebra::{storage::ContiguousStorageMut, ComplexField, Dim, Matrix, Vector};
+use nalgebra::{
+    storage::{IsContiguous, RawStorageMut, Storage},
+    ComplexField, Dim, Matrix, Vector,
+};
 
 /// A least squares minimization problem.
 ///
@@ -7,15 +10,15 @@ use nalgebra::{storage::ContiguousStorageMut, ComplexField, Dim, Matrix, Vector}
 /// for a usage example.
 pub trait LeastSquaresProblem<F, M, N>
 where
-    F: ComplexField,
+    F: ComplexField + Copy,
     N: Dim,
     M: Dim,
 {
     /// Storage type used for the residuals. Use `nalgebra::storage::Owned<F, M>`
     /// if you want to use `VectorN` or `MatrixMN`.
-    type ResidualStorage: ContiguousStorageMut<F, M>;
-    type JacobianStorage: ContiguousStorageMut<F, M, N>;
-    type ParameterStorage: ContiguousStorageMut<F, N> + Clone;
+    type ResidualStorage: RawStorageMut<F, M> + Storage<F, M> + IsContiguous;
+    type JacobianStorage: RawStorageMut<F, M, N> + Storage<F, M, N> + IsContiguous;
+    type ParameterStorage: RawStorageMut<F, N> + Storage<F, N> + IsContiguous + Clone;
 
     /// Set the stored parameters `$\vec{x}$`.
     fn set_params(&mut self, x: &Vector<F, N, Self::ParameterStorage>);

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -11,7 +11,7 @@ use core::iter::repeat;
 use nalgebra::{
     allocator::{Allocator, Reallocator},
     convert,
-    storage::{ContiguousStorageMut, Storage},
+    storage::{IsContiguous, RawStorage, RawStorageMut, Storage},
     DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, Matrix, OMatrix, OVector, Vector,
 };
 use num_traits::Float;
@@ -29,10 +29,10 @@ use crate::utils::{dot, enorm, epsmch};
 /// ```
 pub struct PivotedQR<F, M, N, S>
 where
-    F: nalgebra::RealField + Float,
+    F: nalgebra::RealField + Float + Copy,
     M: Dim + DimMin<N>,
     N: Dim,
-    S: ContiguousStorageMut<F, M, N>,
+    S: RawStorageMut<F, M, N> + IsContiguous,
     DefaultAllocator: Allocator<F, N> + Allocator<usize, N>,
 {
     /// The column norms of the input matrix `$\mathbf{A}$`
@@ -50,10 +50,10 @@ where
 
 impl<F, M, N, S> PivotedQR<F, M, N, S>
 where
-    F: nalgebra::RealField + Float,
+    F: nalgebra::RealField + Float + Copy,
     M: Dim + DimMin<N> + DimMax<N>,
     N: Dim,
-    S: ContiguousStorageMut<F, M, N>,
+    S: RawStorageMut<F, M, N> + Storage<F, M, N> + IsContiguous,
     DefaultAllocator: Allocator<F, N> + Allocator<F, DimMaximum<M, N>, N> + Allocator<usize, N>,
 {
     /// Create a pivoted QR decomposition of a matrix `$\mathbf{A}\in\R^{m\times n}$`.
@@ -134,7 +134,7 @@ where
         mut b: Vector<F, M, QS>,
     ) -> LinearLeastSquaresDiagonalProblem<F, M, N>
     where
-        QS: ContiguousStorageMut<F, M>,
+        QS: RawStorageMut<F, M> + IsContiguous,
         DefaultAllocator: Reallocator<F, M, N, DimMaximum<M, N>, N>,
     {
         // compute first n-entries of Q^T * b
@@ -200,7 +200,7 @@ where
 /// [`into_least_squares_diagonal_problem`](struct.PivotedQR.html#into_least_squares_diagonal_problem).
 pub struct LinearLeastSquaresDiagonalProblem<F, M, N>
 where
-    F: nalgebra::RealField + Float,
+    F: nalgebra::RealField + Float + Copy,
     M: Dim + DimMax<N>,
     N: Dim,
     DefaultAllocator: Allocator<F, N> + Allocator<F, DimMaximum<M, N>, N> + Allocator<usize, N>,
@@ -221,7 +221,7 @@ where
 
 pub struct CholeskyFactor<'a, F, M, N>
 where
-    F: nalgebra::RealField,
+    F: nalgebra::RealField + Copy,
     M: Dim + DimMax<N>,
     N: Dim,
     DefaultAllocator: Allocator<F, N> + Allocator<F, DimMaximum<M, N>, N> + Allocator<usize, N>,
@@ -236,7 +236,7 @@ where
 
 impl<'a, F, M, N> CholeskyFactor<'a, F, M, N>
 where
-    F: nalgebra::RealField,
+    F: nalgebra::RealField + Copy,
     M: Dim + DimMin<N> + DimMax<N>,
     N: Dim,
     DefaultAllocator: Allocator<F, N> + Allocator<F, DimMaximum<M, N>, N> + Allocator<usize, N>,
@@ -294,7 +294,7 @@ where
 
 impl<F, M, N> LinearLeastSquaresDiagonalProblem<F, M, N>
 where
-    F: nalgebra::RealField + Float,
+    F: nalgebra::RealField + Float + Copy,
     M: Dim + DimMin<N> + DimMax<N>,
     N: Dim,
     DefaultAllocator: Allocator<F, N> + Allocator<F, DimMaximum<M, N>, N> + Allocator<usize, N>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,8 +2,8 @@ use crate::LeastSquaresProblem;
 use alloc::{format, string::String};
 use core::cell::RefCell;
 use nalgebra::{
-    allocator::Allocator, convert, storage::Storage, Complex, ComplexField, DefaultAllocator, Dim,
-    Matrix, OMatrix, RealField, Vector, U1,
+    allocator::Allocator, convert, storage::RawStorage, storage::Storage, Complex, ComplexField,
+    DefaultAllocator, Dim, Matrix, OMatrix, RealField, Vector, U1,
 };
 use num_traits::float::Float;
 
@@ -64,7 +64,7 @@ cfg_if::cfg_if! {
 /// #     p: Vector2<F>,
 /// # }
 /// #
-/// # impl<F: ComplexField> LeastSquaresProblem<F, U2, U2> for ExampleProblem<F> {
+/// # impl<F: ComplexField + Copy> LeastSquaresProblem<F, U2, U2> for ExampleProblem<F> {
 /// #     type ParameterStorage = Owned<F, U2>;
 /// #     type ResidualStorage = Owned<F, U2>;
 /// #     type JacobianStorage = Owned<F, U2, U2>;
@@ -104,7 +104,7 @@ pub fn differentiate_numerically<F, N, M, O>(
     problem: &mut O,
 ) -> Option<Matrix<F, M, N, O::JacobianStorage>>
 where
-    F: RealField + Float,
+    F: RealField + Float + Copy,
     N: Dim,
     M: Dim,
     O: LeastSquaresProblem<F, M, N>,
@@ -163,7 +163,7 @@ where
 /// }
 ///
 /// // Implement LeastSquaresProblem to be usable with complex numbers
-/// impl<F: ComplexField> LeastSquaresProblem<F, U2, U2> for ExampleProblem<F> {
+/// impl<F: ComplexField + Copy> LeastSquaresProblem<F, U2, U2> for ExampleProblem<F> {
 ///     // ... omitted ...
 /// #     type ParameterStorage = Owned<F, U2>;
 /// #     type ResidualStorage = Owned<F, U2>;
@@ -213,7 +213,7 @@ pub fn differentiate_holomorphic_numerically<F, N, M, O>(
     problem: &mut O,
 ) -> Option<OMatrix<F, M, N>>
 where
-    F: RealField,
+    F: RealField + Copy,
     N: Dim,
     M: Dim,
     O: LeastSquaresProblem<Complex<F>, M, N>,
@@ -275,7 +275,7 @@ pub(crate) fn dwarf<F: Float>() -> F {
 #[inline]
 pub(crate) fn enorm<F, N, VS>(v: &Vector<F, N, VS>) -> F
 where
-    F: nalgebra::RealField + Float,
+    F: nalgebra::RealField + Float + Copy,
     N: Dim,
     VS: Storage<F, N, U1>,
 {
@@ -339,7 +339,7 @@ where
 /// Dot product between two vectors
 pub(crate) fn dot<F, N, AS, BS>(a: &Vector<F, N, AS>, b: &Vector<F, N, BS>) -> F
 where
-    F: nalgebra::RealField,
+    F: nalgebra::RealField + Copy,
     N: Dim,
     AS: Storage<F, N, U1>,
     BS: Storage<F, N, U1>,

--- a/src/utils/finite_difference.rs
+++ b/src/utils/finite_difference.rs
@@ -19,7 +19,7 @@ const STEP_RATIO: f64 = 2.;
 ///   with the step size. Half the step size and repeat for a fixed amount of steps.
 /// - Compute the Richardson extrapolation and perform Wynn's epsilon algorithm.
 /// - Compute an error estimate and return the approximation with minimal error.
-pub fn derivative<F: Float + RealField>(x: F, f: impl Fn(F) -> Option<F>) -> Option<F> {
+pub fn derivative<F: Float + RealField + Copy>(x: F, f: impl Fn(F) -> Option<F>) -> Option<F> {
     const STEPS: usize = 15;
     let step_ratio: F = convert(STEP_RATIO);
     let mut quotients = Vec::with_capacity(STEPS);
@@ -136,7 +136,7 @@ fn wynn_extrapolate<F: Float>(estimates: Vec<F>) -> Option<Vec<(F, F)>> {
     Some(derivatives)
 }
 
-fn richardson_extrapolate<F: RealField>(evaluations: Vec<F>) -> Option<Vec<F>> {
+fn richardson_extrapolate<F: RealField + Copy>(evaluations: Vec<F>) -> Option<Vec<F>> {
     const STEP: i32 = 2;
     const ORDER: i32 = 2;
     let step_ratio: F = convert(STEP_RATIO);


### PR DESCRIPTION
Also update `arrsac` to 0.9 and `sample-consensus` to 1.0.2.

`ContiguousStorageMut<F, M>` has been replaced with `RawStorageMut<F, M> + Storage<F, M> + IsContiguous`.

The `simba::RealField` and `simba::ComplexField` in the new `nalgebra` version don't implement the `Copy` trait anymore, so that's been manually added.