### PR TITLE
Calculate Jacobians with forward AD from num-dual

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ minpack-compat = []
 nalgebra = { version = "0.34", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 cfg-if = "1.0.1"
+num-dual = { version = "0.13", optional = true }
 
 [dev-dependencies]
 arrsac = "0.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,12 +115,16 @@ extern crate alloc;
 
 mod lm;
 mod problem;
+#[cfg(feature = "num-dual")]
+mod problem_ad;
 mod qr;
 mod trust_region;
 pub(crate) mod utils;
 
 pub use lm::TerminationReason;
 pub use problem::LeastSquaresProblem;
+#[cfg(feature = "num-dual")]
+pub use problem_ad::{ADWrapper, LeastSquaresProblemAD};
 
 pub use utils::{differentiate_holomorphic_numerically, differentiate_numerically};
 

--- a/src/problem_ad.rs
+++ b/src/problem_ad.rs
@@ -1,0 +1,88 @@
+use nalgebra::{
+    ComplexField, DefaultAllocator, Dim, Matrix, OMatrix, OVector, Owned, U1, Vector,
+    allocator::Allocator,
+};
+use num_dual::{DualNum, DualNumFloat, jacobian};
+
+use crate::LeastSquaresProblem;
+
+/// A least squares minimization problem.
+///
+/// This is what [`LevenbergMarquardt`](struct.LevenbergMarquardt.html) needs
+/// to compute the residuals and the Jacobian. See the [module documentation](index.html)
+/// for a usage example.
+pub trait LeastSquaresProblemAD<F, M, N>
+where
+    F: ComplexField + Copy,
+    N: Dim,
+    M: Dim,
+    DefaultAllocator: Allocator<N> + Allocator<M>,
+{
+    /// Compute the residual vector.
+    fn residuals<D: DualNum<F>>(&self, x: OVector<D, N>) -> Option<OVector<D, M>>
+    where
+        DefaultAllocator: Allocator<M> + Allocator<N>;
+}
+
+pub struct ADWrapper<T, F, M, N>
+where
+    F: ComplexField + Copy,
+    M: Dim,
+    N: Dim,
+    DefaultAllocator: Allocator<M> + Allocator<N> + Allocator<M, N>,
+{
+    problem: T,
+    parameters: OVector<F, N>,
+    residuals: Option<(OVector<F, M>, OMatrix<F, M, N>)>,
+}
+
+impl<T, F, M, N> ADWrapper<T, F, M, N>
+where
+    T: LeastSquaresProblemAD<F, M, N>,
+    F: ComplexField + Copy + DualNum<F> + DualNumFloat,
+    M: Dim,
+    N: Dim,
+    DefaultAllocator: Allocator<M> + Allocator<U1, N> + Allocator<N> + Allocator<M, N>,
+{
+    pub fn new(problem: T, parameters: OVector<F, N>) -> Self {
+        let residuals = jacobian(|x| problem.residuals(x), &parameters);
+        Self {
+            problem,
+            parameters,
+            residuals,
+        }
+    }
+}
+
+impl<
+    T: LeastSquaresProblemAD<F, M, N>,
+    F: ComplexField + Copy + DualNum<F> + DualNumFloat,
+    M: Dim,
+    N: Dim,
+> LeastSquaresProblem<F, M, N> for ADWrapper<T, F, M, N>
+where
+    DefaultAllocator: Allocator<M> + Allocator<U1, N> + Allocator<N> + Allocator<M, N>,
+{
+    type ResidualStorage = Owned<F, M>;
+
+    type JacobianStorage = Owned<F, M, N>;
+
+    type ParameterStorage = Owned<F, N>;
+
+    fn set_params(&mut self, x: &OVector<F, N>) {
+        self.parameters.copy_from(x);
+        self.residuals = jacobian(|x| self.problem.residuals(x), x)
+    }
+
+    fn params(&self) -> Vector<F, N, Self::ParameterStorage> {
+        self.parameters.clone()
+    }
+
+    fn residuals(&self) -> Option<Vector<F, M, Self::ResidualStorage>> {
+        self.residuals.as_ref().map(|(res, _)| res.clone())
+    }
+
+    fn jacobian(&self) -> Option<Matrix<F, M, N, Self::JacobianStorage>> {
+        self.residuals.as_ref().map(|(_, jac)| jac.clone())
+    }
+}

--- a/tests/line_fitting_ad.rs
+++ b/tests/line_fitting_ad.rs
@@ -1,0 +1,146 @@
+#![cfg(feature = "num-dual")]
+use arrsac::Arrsac;
+use levenberg_marquardt::{
+    ADWrapper, LeastSquaresProblem, LeastSquaresProblemAD, LevenbergMarquardt,
+};
+use nalgebra::{DVector, Dyn, SVector, U2, Vector2};
+use num_dual::DualNum;
+use rand::{
+    Rng, SeedableRng,
+    distr::{Distribution, Uniform},
+};
+use rand_chacha::ChaCha20Rng;
+use sample_consensus::{Consensus, Estimator, Model};
+
+type F = f64;
+
+const LINES_TO_ESTIMATE: usize = 1000;
+
+#[derive(Debug, Clone)]
+struct Line<D: DualNum<F> = F> {
+    normal_angle: D,
+    c: D,
+}
+
+impl<D: DualNum<F>> Line<D> {
+    fn xy_residuals(&self, point: Vector2<F>) -> Vector2<D> {
+        let normal = self.normal();
+        &normal * (self.c.clone() - normal.dot(&point.map(D::from)))
+    }
+
+    fn into_vec(self) -> Vector2<D> {
+        Vector2::new(self.normal_angle, self.c)
+    }
+
+    fn from_vec(v: Vector2<D>) -> Self {
+        let [[normal_angle, c]] = v.data.0;
+        Self { normal_angle, c }
+    }
+
+    fn norm_cosine_distance(&self, other: &Self) -> D {
+        -self.normal().dot(&other.normal()).abs() + 1.0
+    }
+
+    fn normal(&self) -> Vector2<D> {
+        Vector2::new(self.normal_angle.cos(), self.normal_angle.sin())
+    }
+}
+
+impl Model<Vector2<F>> for Line {
+    fn residual(&self, point: &Vector2<F>) -> F {
+        (self.normal().dot(point) - self.c).abs()
+    }
+}
+
+struct LineEstimator;
+
+impl Estimator<Vector2<F>> for LineEstimator {
+    type Model = Line;
+    type ModelIter = std::iter::Once<Line>;
+    const MIN_SAMPLES: usize = 2;
+
+    fn estimate<I>(&self, mut data: I) -> Self::ModelIter
+    where
+        I: Iterator<Item = Vector2<F>> + Clone,
+    {
+        let a = data.next().unwrap();
+        let b = data.next().unwrap();
+        let normal = Vector2::new(a.y - b.y, b.x - a.x).normalize();
+        let c = -normal.dot(&b);
+        let normal_angle = F::atan2(normal[1], normal[0]);
+        std::iter::once(Line { normal_angle, c })
+    }
+}
+
+struct LineFittingOptimizationProblem<'a> {
+    points: &'a [Vector2<F>],
+}
+
+impl<'a> LeastSquaresProblemAD<F, Dyn, U2> for LineFittingOptimizationProblem<'a> {
+    fn residuals<D: DualNum<F>>(&self, x: SVector<D, 2>) -> Option<DVector<D>> {
+        let model = Line::from_vec(x);
+        let residual_data = self
+            .points
+            .iter()
+            .flat_map(|&point| {
+                let [vec] = model.xy_residuals(point).data.0;
+                vec
+            })
+            .collect();
+        Some(DVector::from_vec(residual_data))
+    }
+}
+
+#[test]
+fn lines() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    // The max candidate hypotheses had to be increased dramatically to ensure all 1000 cases find a
+    // good-fitting line.
+    let mut arrsac = Arrsac::new(5.0, ChaCha20Rng::seed_from_u64(1));
+    let mut would_have_failed = false;
+    for _ in 0..LINES_TO_ESTIMATE {
+        // Generate <a, b> and normalize.
+        let normal =
+            Vector2::new(rng.random_range(-10.0..10.0), rng.random_range(-10.0..10.0)).normalize();
+        let normal_angle = F::atan2(normal[1], normal[0]);
+        // Get parallel ray.
+        let ray = Vector2::new(normal.y, -normal.x);
+        // Generate random c.
+        let c = rng.random_range(-10.0..10.0);
+
+        // Generate random number of points.
+        let num = rng.random_range(100..1000);
+        // The points should be no more than 5.0 away from the line and be evenly distributed away from the line.
+        let residuals = Uniform::new(-5.0, 5.0).unwrap();
+        // The points must be generated along the line, but the distance should be bounded to make it more difficult.
+        let distances = Uniform::new(-50.0, 50.0).unwrap();
+        // Generate the points.
+        let points: Vec<Vector2<F>> = (0..num)
+            .map(|_| {
+                let residual: F = residuals.sample(&mut rng);
+                let distance: F = distances.sample(&mut rng);
+                let along = ray * distance;
+                let against = (residual - c) * normal;
+                along + against
+            })
+            .collect();
+
+        let model = arrsac
+            .model(&LineEstimator, points.iter().copied())
+            .expect("unable to estimate a model");
+        // Now perform Levenberg-Marquardt.
+        let problem = LineFittingOptimizationProblem { points: &points };
+        let ad_problem = ADWrapper::new(problem, model.clone().into_vec());
+        let (problem, report) = LevenbergMarquardt::new().minimize(ad_problem);
+        assert!(report.termination.was_successful());
+        let real_model = Line { normal_angle, c };
+        would_have_failed = would_have_failed || model.norm_cosine_distance(&real_model) >= 0.01;
+        let new_cosine_distance =
+            Line::from_vec(problem.params()).norm_cosine_distance(&real_model);
+
+        // Check the slope using the cosine distance.
+        assert!(new_cosine_distance < 0.001, "slope out of expected range");
+    }
+    // test that there were initial guesses that wouldn't have been enough
+    assert!(would_have_failed);
+}


### PR DESCRIPTION
Hello,

this is in reference to #24 . Jacobians are calculated using forward mode automatic differentiation provided by the `num-dual` crate. The user only needs to implement the residuals using the `DualNum` trait bound, everything else comes for free (implementation-wise). Because, with AD the residuals and Jacobians are always evaluated simultaneously, I simplified the interface for the `LeastSquaresProblemAD` a bit compared to the `LeastSquaresProblem` trait. Also, `num-dual` uses the `Owned` data storage in `nalgebra`, so this is also hardcoded here, but might be relaxed if that is necessary.

To validate, I adapted the line fitting example in `tests`. This is still a bit raw and I am happy to clean it up and document it properly if you are interested in having this feature.