### PR TITLE
Bump nalgebra to 0.35 to drop unmaintained `paste` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = []
 minpack-compat = []
 
 [dependencies]
-nalgebra = { version = "0.34", default-features = false }
+nalgebra = { version = "0.35", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 cfg-if = "1.0.1"
 
@@ -33,7 +33,7 @@ cfg-if = "1.0.1"
 arrsac = "0.11.0"
 rand = { version = "0.9.2", default-features = false }
 rand_chacha = "0.9.0"
-nalgebra = "0.34"
+nalgebra = "0.35"
 sample-consensus = "1.0.2"
 approx = "0.5.1"
 


### PR DESCRIPTION
## Summary

`levenberg-marquardt 0.15.0` depends on `nalgebra 0.34`, whose transitive
dependency `simba 0.9` pulls in the [`paste`](https://crates.io/crates/paste)
crate. `paste` is now unmaintained and flagged by
[RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436), so every
downstream user of this crate inherits the advisory.

## Fix

`nalgebra 0.35` bumps its requirement to `simba 0.10`, which removed `paste`
entirely. This PR updates the `nalgebra` requirement (in both `[dependencies]`
and `[dev-dependencies]`) from `0.34` to `0.35`:


## Verification

All checks run locally against `nalgebra 0.35.0` + `simba 0.10.0`, **with no
source changes** (nalgebra 0.35 introduces no breaking API changes affecting
this crate):

- `cargo build` — succeeds.
- `cargo test` — all unit, integration, and doc tests pass.
- `cargo rustc --target=armv7a-none-eabi --manifest-path=ensure_no_std/Cargo.toml`
  — the `no_std` check still builds.
- `cargo clippy --all-targets --tests -- -D warnings` — clean.

## Notes for maintainers

- **MSRV:** nalgebra 0.35 raises the minimum supported Rust version to **1.89.0**.
- **Semver:** `nalgebra` is part of this crate's public API (`LeastSquaresProblem`
  is generic over nalgebra types), so exposing a new nalgebra major version is a
  breaking change for downstream users. This likely warrants a **0.16.0** release.
  I left the package version unchanged so you can decide the release.
